### PR TITLE
Explain geo app frame

### DIFF
--- a/VEP-014.txt
+++ b/VEP-014.txt
@@ -7,7 +7,7 @@ Action: Addition
 Label: Spatial Profile
 Description: An observable obtained along a one-dimensional spatial path.
 Relationships: narrower than #spatially-resolved-dataset
-Used-in: TBD
+Used-in: http://radioarchive.inaf.it/
 
 Rationale:
 Single dish radio observations where a cross-shaped scan is executed on
@@ -15,14 +15,25 @@ a target object are commonly performed for flux measurements or pointing
 correction calculations, and are best described as a spatial profile.
 Typically, the spatial length of each arm of the cross is larger than
 the spatial resolution to allow for a proper background subtraction.
-Other radio observations (usually performed at high frequency) that can be described as spatial profiles
-are elevation scans on the empty sky executed to calculate opacity
-corrections.
-Another case for spatial-profile would be when a planetary probe takes
-measurements along its flight path.
+Other radio observations (usually performed at high frequency) that can
+be described as spatial profiles are elevation scans on the empty sky
+executed to calculate opacity corrections.  Another case for
+spatial-profile would be when a planetary probe takes measurements along
+its flight path.
 
 Such observational data need a dedicated term for their discovery
 because they have calibration, processing and analysis modes rather
-distinct from other data product types.
-However, further differentiation among various types of profiles may be considered if
+distinct from other data product types.  However, further
+differentiation among various types of profiles may be considered if
 additional use cases are formulated.
+
+Discussion:
+
+	The reaction to http://mail.ivoa.net/pipermail/radioig/2024/000108.html
+	were favourable.  There was a question whether, for instance, slit
+	spectra ought to count as spatial profiles; but nobody wanted to
+	champion this, and it seems sufficiently doubtful that the creation
+	of such a relationship can wait until we have gathered experience on
+	whether that might be useful.
+
+	The new term was approved by the TCG on 2024-05-19.

--- a/VEP-new.txt
+++ b/VEP-new.txt
@@ -1,0 +1,27 @@
+Vocabulary: http://www.ivoa.net/rdf/refframe
+Author: Markus Demleitner <msdemlei@ari.uni-heidelberg.de> and J.J. Kavelaars
+Date: 2024-11-17
+
+New Term: geo_app
+Action: Modification
+Label: Geocentric Apparent Positions
+Description: Positions given as observed by a fictitious observer at the
+	Earth’ s centre for the equator of observation.
+Relationships: narrower than #EQUATORIAL
+Used-in: VOTable legacy
+
+Rationale:
+When the legacy VOTable terms were added to the refframe vocabulary
+(which was necessary to keep validity criteria when VOTable changed
+COOSYS/@system to being controlled by this vocabulary), nobody rememberd
+what geo_app might have meant.  It recently turned out that it must
+have been “Geocentric Apparent”, a frame used primarly in geodesy and
+solar system science.  It is documented to some extent in
+https://starlink.eao.hawaii.edu/docs/sun211.htx/sun211ss454.html.
+
+This VEP replaces label, description, and relationship for the concept.
+At this point, this is a deprecated concept, and since it is mixing
+refposition and frame ("geocentre" vs. "apparent positions at equator of
+epoch"), we quite certainly won't want anyone to use it.  We still want
+to update the concept metadata and hence ask for exemption from the
+“must be used somewhere” rule.


### PR DESCRIPTION
When the legacy VOTable terms were added to the refframe vocabulary
(which was necessary to keep validity criteria when VOTable changed
COOSYS/@system to being controlled by this vocabulary), nobody rememberd
what geo_app might have meant.  It recently turned out that it must
have been “Geocentric Apparent”, a frame used primarly in geodesy and
solar system science.  It is documented to some extent in
https://starlink.eao.hawaii.edu/docs/sun211.htx/sun211ss454.html.

This VEP replaces label, description, and relationship for the concept.
At this point, this is a deprecated concept, and since it is mixing
refposition and frame ("geocentre" vs. "apparent positions at equator of
epoch"), we quite certainly won't want anyone to use it.  We still want
to update the concept metadata and hence ask for exemption from the
“must be used somewhere” rule.