### PR TITLE
Adding VEP for UCDSyntaxCode in ivoasem vocabulary

### DIFF
--- a/VEP-new.txt
+++ b/VEP-new.txt
@@ -2,10 +2,23 @@ Vocabulary: http://www.ivoa.net/rdf/ivoasem
 Author: elsa.david@obspm.fr
 Date: 2025-11-20
 
-Term: UCDSyntaxCode
+Term: ucd-syntax-code
 Action: Addition
-Label: UCD Syntax Code
-Description: The object of this property indicates what syntax code (P, Q, S, ect)is used for the UCD subject of this property
+Label: has UCD syntax code
+Description: UCD atoms canot be freely combined.  Rather, each atom has
+	a syntax code, which is one of p (only primary position), s (not in
+	primary position), q (freely positionable), e (can be followed by a
+	spectral atom), c (can be followed by two spectral atoms), or v (can
+	be followed by a frame or axis atom).
 
-Rationale: 
-this new term specify that a specific UCD has a UCD syntax as defined in https://ivoa.net/documents/UCD1+/20241218/EN-UCDlist-1.6-20241218.html and as discussed in https://github.com/ivoa-std/Vocabularies/pull/31. 
+Rationale:
+If we want to model UCDs as an RDF vocabulary, we will have to have some
+means to represent the syntax codes as defined in the current UCDList document
+https://ivoa.net/documents/UCD1+/.  A discussion leading up to something
+like this proposal is found in https://github.com/ivoa-std/Vocabularies/pull/31.
+
+Certain RDF formalisms would let us define the property's domain.  This
+would have the advantage that a suitable validator could ensure that we
+only assign allowed syntax codes; however, given that changes are
+infrequent and well-reviewed, the benefit of that seems too minor to
+justify the extra effort of extending Vocabularies in the VO.

--- a/VEP-new.txt
+++ b/VEP-new.txt
@@ -1,0 +1,11 @@
+Vocabulary: http://www.ivoa.net/rdf/ivoasem
+Author: elsa.david@obspm.fr
+Date: 2025-11-20
+
+Term: UCDSyntaxCode
+Action: Addition
+Label: UCD Syntax Code
+Description: The object of this property indicates what syntax code (P, Q, S, ect)is used for the UCD subject of this property
+
+Rationale: 
+this new term specify that a specific UCD has a UCD syntax as defined in https://ivoa.net/documents/UCD1+/20241218/EN-UCDlist-1.6-20241218.html and as discussed in https://github.com/ivoa-std/Vocabularies/pull/31. 


### PR DESCRIPTION
Here is a PR for the term UCDSyntaxCode un ivoasem vocabulary. It was discussed [here](https://github.com/ivoa-std/Vocabularies/pull/31) and during IVOAInteropNov to use it as a property in the UCD vocabulary. 